### PR TITLE
Replace hard coded canvas to fill the complete view port.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -71,8 +71,8 @@
 <body>
   <script src="https://d3js.org/d3.v3.min.js" charset="utf-8"></script>
   <script>
-      var width = 1440,  // width and height of the SVG canvas
-          height = 900;
+      var width = '100vw',  // width and height of the SVG canvas
+          height = '100vh';
       // A list of node objects.  We represent each node as {id: "name"}, but the D3
       // system will decorate the node with addtional fields, notably x: and y: for
       // the force layout and index" as part of the binding mechanism.


### PR DESCRIPTION
This PR replaces the hard-coded absolute dimension values of the SVG canvas by values relative to the current viewport. This allows _dvizz_ to fill the complete visible browser viewport.